### PR TITLE
Fix headdb dir

### DIFF
--- a/AWS_OpsManager/opsmanager_config.py
+++ b/AWS_OpsManager/opsmanager_config.py
@@ -62,7 +62,7 @@ def setHeadDirectory(host, internalDNS):
         "configured": True,
         "machine": {
             "machine": internalDNS,
-            "headRootDirectory": "/headdb"
+            "headRootDirectory": "/headdb/"
         }
     })
     headers = {


### PR DESCRIPTION
OpsManager expects a directory with trailing slash for the backup deamon, otherwise java complains about:

java.lang.RuntimeException: Directories must end in the system path separator ('/')
	at com.xgen.svc.brs.grid.BackupDaemonConfiguration.<init>(BackupDaemonConfiguration.java:166)
	at com.xgen.svc.brs.grid.BackupDaemonConfiguration.<init>(BackupDaemonConfiguration.java:161)
	at com.xgen.svc.brs.grid.Daemon.getConfiguration(Daemon.java:773)
	at com.xgen.svc.brs.grid.Daemon.getConfiguration(Daemon.java:826)
	at com.xgen.svc.brs.grid.Daemon.initialize(Daemon.java:840)
	at com.xgen.svc.brs.grid.Daemon.main(Daemon.java:1008)